### PR TITLE
added Google OAuth

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -27,3 +27,8 @@ S3_ENDPOINT=http://localhost:20102
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 AUTH_SECRET=CHANGE_TO_RANDOM_SECRET_32_CHARS
 AUTH_URL=http://localhost:20100
+
+# Google OAuth
+# Get credentials from: https://console.cloud.google.com/apis/credentials
+AUTH_GOOGLE_ID=CHANGE_TO_GOOGLE_CLIENT_ID
+AUTH_GOOGLE_SECRET=CHANGE_TO_GOOGLE_CLIENT_SECRET

--- a/.env.production.example
+++ b/.env.production.example
@@ -27,3 +27,7 @@ S3_ENDPOINT=http://garage:3900
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 AUTH_SECRET=CHANGE_TO_RANDOM_SECRET_32_CHARS
 AUTH_URL=https://yourdomain.com
+
+# Google OAuth
+AUTH_GOOGLE_ID=CHANGE_TO_GOOGLE_CLIENT_ID
+AUTH_GOOGLE_SECRET=CHANGE_TO_GOOGLE_CLIENT_SECRET

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,27 @@
+# v0.2.x -> v0.3.0
+
+### `.env.local` and `.env.production`
+
+Add the following for Google OAuth:
+
+```.env
+# Google OAuth
+AUTH_GOOGLE_ID=your-google-client-id
+AUTH_GOOGLE_SECRET=your-google-client-secret
+```
+
+Get credentials from the [Google Cloud Console](https://console.cloud.google.com/apis/credentials):
+1. Sign in with any Google account.
+2. Create a new project.
+3. Set up OAuth consent screen.
+4. Go to Credentials and create credentials.
+5. Select Web application.
+6. Add authorized redirect URI: `https://yourdomain.com/api/auth/callback/google`
+7. For local development use: `http://localhost:20100/api/auth/callback/google`
+8. Get the Client ID and Secret.
+
+---
+
 # v0.1.x -> v0.2.0
 
 ### `.env.local` and .env.production

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -27,7 +27,9 @@
     "haveAccount": "لديك حساب بالفعل؟",
     "passwordMismatch": "كلمتا المرور غير متطابقتين",
     "registrationFailed": "فشل التسجيل. يرجى المحاولة مرة أخرى.",
-    "emailExists": "يوجد حساب بهذا البريد الإلكتروني بالفعل."
+    "emailExists": "يوجد حساب بهذا البريد الإلكتروني بالفعل.",
+    "orDivider": "أو",
+    "continueWithGoogle": "المتابعة مع Google"
   },
   "about": {
     "title": "حول SustainableCrafting",

--- a/messages/de.json
+++ b/messages/de.json
@@ -27,7 +27,9 @@
     "haveAccount": "Bereits ein Konto?",
     "passwordMismatch": "Passwörter stimmen nicht überein",
     "registrationFailed": "Registrierung fehlgeschlagen. Bitte versuchen Sie es erneut.",
-    "emailExists": "Ein Konto mit dieser E-Mail-Adresse existiert bereits."
+    "emailExists": "Ein Konto mit dieser E-Mail-Adresse existiert bereits.",
+    "orDivider": "oder",
+    "continueWithGoogle": "Weiter mit Google"
   },
   "about": {
     "title": "Über SustainableCrafting",

--- a/messages/en.json
+++ b/messages/en.json
@@ -27,7 +27,9 @@
     "haveAccount": "Already have an account?",
     "passwordMismatch": "Passwords do not match",
     "registrationFailed": "Registration failed. Please try again.",
-    "emailExists": "An account with this email already exists."
+    "emailExists": "An account with this email already exists.",
+    "orDivider": "or",
+    "continueWithGoogle": "Continue with Google"
   },
   "about": {
     "title": "About SustainableCrafting",

--- a/messages/es.json
+++ b/messages/es.json
@@ -27,7 +27,9 @@
     "haveAccount": "¿Ya tienes una cuenta?",
     "passwordMismatch": "Las contraseñas no coinciden",
     "registrationFailed": "Error al registrarse. Inténtalo de nuevo.",
-    "emailExists": "Ya existe una cuenta con este correo electrónico."
+    "emailExists": "Ya existe una cuenta con este correo electrónico.",
+    "orDivider": "o",
+    "continueWithGoogle": "Continuar con Google"
   },
   "about": {
     "title": "Acerca de SustainableCrafting",

--- a/messages/hi.json
+++ b/messages/hi.json
@@ -27,7 +27,9 @@
     "haveAccount": "पहले से खाता है?",
     "passwordMismatch": "पासवर्ड मेल नहीं खाते",
     "registrationFailed": "पंजीकरण विफल। कृपया पुनः प्रयास करें।",
-    "emailExists": "इस ईमेल से पहले से एक खाता मौजूद है।"
+    "emailExists": "इस ईमेल से पहले से एक खाता मौजूद है।",
+    "orDivider": "या",
+    "continueWithGoogle": "Google से जारी रखें"
   },
   "about": {
     "title": "सस्टेनेबल क्राफ्टिंग के बारे में",

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -81,6 +81,42 @@ export function LoginForm() {
                     >
                         {loading ? t('signingIn') : t('login')}
                     </Button>
+                    <div className="relative my-4">
+                        <div className="absolute inset-0 flex items-center">
+                            <span className="w-full border-t" />
+                        </div>
+                        <div className="relative flex justify-center text-xs uppercase">
+                            <span className="bg-card px-2 text-muted-foreground">
+                                {t('orDivider')}
+                            </span>
+                        </div>
+                    </div>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full"
+                        onClick={() => signIn('google', { callbackUrl: '/crafts' })}
+                    >
+                        <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                            <path
+                                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                                fill="#4285F4"
+                            />
+                            <path
+                                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                                fill="#34A853"
+                            />
+                            <path
+                                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                                fill="#FBBC05"
+                            />
+                            <path
+                                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                                fill="#EA4335"
+                            />
+                        </svg>
+                        {t('continueWithGoogle')}
+                    </Button>
                     <p className="text-center text-sm text-muted-foreground">
                         {t('noAccount')}{' '}
                         <Link

--- a/src/components/auth/RegisterForm.tsx
+++ b/src/components/auth/RegisterForm.tsx
@@ -138,6 +138,42 @@ export function RegisterForm() {
                     >
                         {loading ? t('registering') : t('register')}
                     </Button>
+                    <div className="relative my-4">
+                        <div className="absolute inset-0 flex items-center">
+                            <span className="w-full border-t" />
+                        </div>
+                        <div className="relative flex justify-center text-xs uppercase">
+                            <span className="bg-card px-2 text-muted-foreground">
+                                {t('orDivider')}
+                            </span>
+                        </div>
+                    </div>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full"
+                        onClick={() => signIn('google', { callbackUrl: '/crafts' })}
+                    >
+                        <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+                            <path
+                                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                                fill="#4285F4"
+                            />
+                            <path
+                                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                                fill="#34A853"
+                            />
+                            <path
+                                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                                fill="#FBBC05"
+                            />
+                            <path
+                                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                                fill="#EA4335"
+                            />
+                        </svg>
+                        {t('continueWithGoogle')}
+                    </Button>
                     <p className="text-center text-sm text-muted-foreground">
                         {t('haveAccount')}{' '}
                         <Link

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import NextAuth from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
+import Google from 'next-auth/providers/google'
 import { PrismaAdapter } from '@auth/prisma-adapter'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
@@ -12,6 +13,7 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         signIn: '/login',
     },
     providers: [
+        Google,
         Credentials({
             name: 'credentials',
             credentials: {


### PR DESCRIPTION
## Changes

- Added Google provider to Auth.js configuration
- Added "Continue with Google" button to login and register forms with Google logo
- Added "or" divider between credentials form and Google button
- Added i18n translation keys for all 5 locales (en, es, hi, ar, de)
- Updated .env example files with AUTH_GOOGLE_ID and AUTH_GOOGLE_SECRET placeholders
- Updated MIGRATION.md with Google Cloud Console setup instructions

## Testing Steps

1. Set up Google OAuth credentials in Google Cloud Console
2. Add AUTH_GOOGLE_ID and AUTH_GOOGLE_SECRET to .env.local
3. Run `pnpm dev` and navigate to `/login`
4. Click "Continue with Google"
5. Sign in with a Google account

## Migration Notes

- Added `AUTH_GOOGLE_ID` and `AUTH_GOOGLE_SECRET` to .env — see MIGRATION.md for setup details

## Checklist

- [x] Tests pass locally (`pnpm test-deploy`)
- [x] MIGRATION.md updated
- [x] Feature tested locally